### PR TITLE
Add Finnish translation to signup-form.json

### DIFF
--- a/ghost/i18n/locales/fi/signup-form.json
+++ b/ghost/i18n/locales/fi/signup-form.json
@@ -1,9 +1,9 @@
 {
-    "Email sent": "",
-    "Now check your email!": "",
-    "Please enter a valid email address": "",
-    "Something went wrong, please try again.": "",
-    "Subscribe": "",
-    "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "",
-    "Your email address": ""
+    "Email sent": "Sähköpostiviesti lähetettiin",
+    "Now check your email!": "Tarkista nyt sähköpostisi!",
+    "Please enter a valid email address": "Ole hyvä ja syötä voimassa oleva sähköpostiosoite",
+    "Something went wrong, please try again.": "Jotain meni pieleen, ole hyvä ja yritä uudestaan.",
+    "Subscribe": "Tilaa",
+    "To complete signup, click the confirmation link in your inbox. If it doesn't arrive within 3 minutes, check your spam folder!": "Viimeistelläksesi rekisteröitymisen, klikkaa vahvistuslinkkiä saamassasi sähköpostiviestissä. Jos et saa vahvistuslinkin sisältävää viestiä kolmen minuutin kuluessa, tarkistathan roskapostikansiosi.",
+    "Your email address": "Sähköpostiosoitteesi"
 }


### PR DESCRIPTION
- [x] There's a clear use-case for this code change, explained below
- [x] Commit message has a short title & references relevant issues
- [ ] The build will pass (run `yarn test:all` and `yarn lint`)

Added the remaining Finnish locale to signup-form.json. Note that tests haven't been run, this was a quick edit. I did triple check the JSON syntax though.